### PR TITLE
Update CHIP-Tools source

### DIFF
--- a/Flash.sh
+++ b/Flash.sh
@@ -73,7 +73,7 @@ if [ -d CHIP-tools ]; then
  git pull 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
  elif [ ! -d CHIP-tools ]; then
- git clone https://github.com/Elfking29/CHIP-tools-2025.git
+ git clone https://github.com/rtxanson/CHIP-tools.git
  cd  CHIP-tools 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
 fi

--- a/Flash.sh
+++ b/Flash.sh
@@ -74,7 +74,7 @@ if [ -d CHIP-tools ]; then
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
  elif [ ! -d CHIP-tools ]; then
  git clone https://github.com/rtxanson/CHIP-tools.git
- cd  CHIP-tools 
+ cd  CHIP-tools-2025 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
 fi
 

--- a/Flash.sh
+++ b/Flash.sh
@@ -73,7 +73,7 @@ if [ -d CHIP-tools ]; then
  git pull 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
  elif [ ! -d CHIP-tools ]; then
- git clone https://github.com/Project-chip-crumbs/CHIP-tools.git
+ git clone https://github.com/Elfking29/CHIP-tools-2025.git
  cd  CHIP-tools 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
 fi

--- a/Flash.sh
+++ b/Flash.sh
@@ -68,13 +68,13 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", GROUP="plug
 sudo udevadm control --reload-rules
 
 echo -e "\n Installing CHIP-tools"
-if [ -d CHIP-tools ]; then
- cd CHIP-tools 
+if [ -d CHIP-tools-2025 ]; then
+ cd CHIP-tools-2025 
  git pull 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
- elif [ ! -d CHIP-tools ]; then
- git clone https://github.com/rtxanson/CHIP-tools.git
- cd  CHIP-tools 
+ elif [ ! -d CHIP-tools-2025 ]; then
+ git clone https://github.com/Elfking29/CHIP-tools-2025
+ cd  CHIP-tools-2025 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
 fi
 

--- a/Flash.sh
+++ b/Flash.sh
@@ -74,7 +74,7 @@ if [ -d CHIP-tools ]; then
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
  elif [ ! -d CHIP-tools ]; then
  git clone https://github.com/rtxanson/CHIP-tools.git
- cd  CHIP-tools-2025 
+ cd  CHIP-tools 
  FEL='sudo sunxi-fel' FASTBOOT='sudo fastboot' SNIB=false ./chip-update-firmware.sh -$flavour
 fi
 


### PR DESCRIPTION
After changes to fastboot (removing the "-i" and "-u" flags) this no longer works on modern Debian. Once these flags are removed, the flasher will work. I changed the source of CHIP-Tools from the default to one that is updated and actually works.